### PR TITLE
Fix double titles on admonitions page

### DIFF
--- a/book/content/admonitions.md
+++ b/book/content/admonitions.md
@@ -37,123 +37,121 @@ It's got a certain charm to it.
 
 ## `attention`
 
-::::::{attention} Attention
+::::::{attention}
 Climate change is real.
 ::::::
 ```text
-::::::{attention} Attention
+::::::{attention}
 Climate change is real.
 ::::::
 ```
 
 ## `caution`
 
-::::::{caution} Caution
+::::::{caution}
 Cliff ahead: Don't drive off it.
 ::::::
 ```text
-::::::{caution} Caution
+::::::{caution}
 Cliff ahead: Don't drive off it.
 ::::::
 ```
 
 ## `danger`
 
-::::::{danger} Danger
+::::::{danger}
 Mad scientist at work!
 ::::::
 ```text
-::::::{danger} Danger
+::::::{danger}
 Mad scientist at work!
 ::::::
 ```
 
 ## `error`
 
-::::::{error} Error
+::::::{error}
 Does not compute.
 ::::::
 ```text
-::::::{error} Error
+::::::{error}
 Does not compute.
 ::::::
 ```
 
 ## `hint`
 
-::::::{hint} Hint
+::::::{hint}
 Insulators insulate, until they are subject to ______ voltage.
 ::::::
 ```text
-::::::{hint} Hint
+::::::{hint}
 Insulators insulate, until they are subject to ______ voltage.
 ::::::
 ```
 
 ## `important`
 
-::::::{important} Important
+::::::{important}
 Tech is not neutral, nor is it apolitical.
 ::::::
 ```text
-::::::{important} Important
+::::::{important}
 Tech is not neutral, nor is it apolitical.
 ::::::
 ```
 
 ## `note`
 
-::::::{note} Note
+::::::{note}
 This is a note.
 ::::::
 ```text
-::::::{note} Note
+::::::{note}
 This is a note.
 ::::::
 ```
 
 ## `seealso`
 
-::::::{seealso} See Also
+::::::{seealso}
 Other relevant information.
 ::::::
 ```text
-::::::{seealso} See Also
+::::::{seealso}
 Other relevant information.
 ::::::
 ```
 
 ## `tip`
 
-::::::{tip} Tip
+::::::{tip}
 25% if the service is good.
 ::::::
 ```text
-::::::{tip} Tip
+::::::{tip}
 25% if the service is good.
 ::::::
 ```
 
 ## `warning`
 
-::::::{warning} Warning
+::::::{warning}
 Reader discretion is strongly advised.
 ::::::
 ```text
-::::::{warning} Warning
+::::::{warning}
 Reader discretion is strongly advised.
 ::::::
 ```
 
 ## `versionadded`
 
-::::::{versionadded} Version Added
-**v0.1.1**  
+::::::{versionadded} v0.1.1
 Here's a version added message.
 ::::::
 ```text
-::::::{versionadded} Version Added
-**v0.1.1**  
+::::::{versionadded} v0.1.1
 Here's a version added message.
 ::::::
 ```
@@ -165,21 +163,18 @@ Here's a version added message.
 Here's a version changed message.
 ::::::
 ```text
-::::::{versionchanged} Version Changed
-**v0.1.1**  
+::::::{versionchanged} v0.1.1
 Here's a version changed message.
 ::::::
 ```
 
 ## `deprecated`
 
-::::::{deprecated} Deprecated
-**v0.1.1**  
+::::::{deprecated} v0.1.1
 Here's a deprecation message.
 ::::::
 ```text
-::::::{deprecated} Deprecated
-**v0.1.1**  
+::::::{deprecated} v0.1.1  
 Here's a deprecation message.
 ::::::
 ```

--- a/book/content/admonitions.md
+++ b/book/content/admonitions.md
@@ -148,22 +148,25 @@ Reader discretion is strongly advised.
 ## `versionadded`
 
 ::::::{versionadded} v0.1.1
+
 Here's a version added message.
 ::::::
 ```text
 ::::::{versionadded} v0.1.1
+
 Here's a version added message.
 ::::::
 ```
 
 ## `versionchanged`
 
-::::::{versionchanged} Version Changed
-**v0.1.1**  
+::::::{versionchanged} v0.1.1
+
 Here's a version changed message.
 ::::::
 ```text
 ::::::{versionchanged} v0.1.1
+
 Here's a version changed message.
 ::::::
 ```
@@ -171,10 +174,12 @@ Here's a version changed message.
 ## `deprecated`
 
 ::::::{deprecated} v0.1.1
+
 Here's a deprecation message.
 ::::::
 ```text
-::::::{deprecated} v0.1.1  
+::::::{deprecated} v0.1.1
+
 Here's a deprecation message.
 ::::::
 ```

--- a/book/content/admonitions.md
+++ b/book/content/admonitions.md
@@ -148,12 +148,10 @@ Reader discretion is strongly advised.
 ## `versionadded`
 
 ::::::{versionadded} v0.1.1
-
 Here's a version added message.
 ::::::
 ```text
 ::::::{versionadded} v0.1.1
-
 Here's a version added message.
 ::::::
 ```
@@ -161,12 +159,10 @@ Here's a version added message.
 ## `versionchanged`
 
 ::::::{versionchanged} v0.1.1
-
 Here's a version changed message.
 ::::::
 ```text
 ::::::{versionchanged} v0.1.1
-
 Here's a version changed message.
 ::::::
 ```
@@ -174,12 +170,10 @@ Here's a version changed message.
 ## `deprecated`
 
 ::::::{deprecated} v0.1.1
-
 Here's a deprecation message.
 ::::::
 ```text
 ::::::{deprecated} v0.1.1
-
 Here's a deprecation message.
 ::::::
 ```


### PR DESCRIPTION
As only the `{admonition}` allows for custom titles, remove those for the others